### PR TITLE
solved 2018 day 13

### DIFF
--- a/2018/src/main/scala/Day13.scala
+++ b/2018/src/main/scala/Day13.scala
@@ -109,7 +109,7 @@ object Day13 extends AdventOfCode:
 				findCollisionPos(remainingCarts, movedCart) match
 					case Some(pos) if remainingCarts.forall(_.loc == pos) => pos
 					case Some(pos) => tick(toMove.tail.filterNot(_.loc == pos), moved.filterNot(_.loc == pos))
-					case None => tick(toMove.tail, moved :+ movedCart.turn(tracks(movedCart.loc)))
+					case None      => tick(toMove.tail, moved :+ movedCart.turn(tracks(movedCart.loc)))
 
 		tick(carts.sortBy(_.loc), Vector.empty[Cart])
 


### PR DESCRIPTION
- About part 2 line 110: technically this is not the position of the last remaining cart, but of the position where the last remaining carts crash for an even number of carts. So now it also (kind of) works for the test input from part 1 (which uses 2 carts).

- About part 2 line 104: this is the place where the actual answer to part 2 is produced since the puzzle input uses an uneven number of carts.

- About parsing the input: I started out with a rather complicated foldLeft which could parse the whole input in one go. I then however had trouble separating the track part from the cart part in my one big collection of tuple2s. I did not think of 'unzip' at that moment, which would have solved my problem easily. Now I go through the input twice in a rather nice way (I think), so I decided to keep it this way. Also because I am not sure what is worse performance/memory wise: 1) parsing the input twice, or 2) maintaining the intermediate accumulated collection in foldLeft.

Quite happy with the outcome :-)